### PR TITLE
chore(plan): check off 019 placeholder in sequencing plan

### DIFF
--- a/todo-app-implementation-sequencing-plan.md
+++ b/todo-app-implementation-sequencing-plan.md
@@ -23,7 +23,7 @@ Wave 1 — Foundations (independent kickoff)
 Backend
 - [ ] .rovodev/todo-app-001_server_migrations_projects_memberships.md
 - [ ] .rovodev/todo-app-005_server_migrations_tags.md
-- [ ] .rovodev/todo-app-019_server_placeholder.md (reserved / gap filler)
+- [x] .rovodev/todo-app-019_server_placeholder.md (reserved / gap filler)
 Shared
 - [ ] .rovodev/todo-app-051_shared_timezone_and_apollo.md (can start; finalize after 008,010)
 - [ ] .rovodev/todo-app-052_shared_offline_and_storage.md


### PR DESCRIPTION
This PR marks `.rovodev/todo-app-019_server_placeholder.md` as completed in Wave 1 by checking off the item in `todo-app-implementation-sequencing-plan.md`.

- Change: [ ] -> [x] for the placeholder item in Wave 1 Backend.
- No code changes.