### PR TITLE
005 — Server: Migrations for Tags

### DIFF
--- a/server/DATABASE.md
+++ b/server/DATABASE.md
@@ -38,10 +38,22 @@ Database migrations are applied automatically on server startup. The server conn
   - created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
   - indices: project_id, user_id
   - unique(project_id, user_id)
+- tags
+  - id TEXT PRIMARY KEY
+  - name TEXT UNIQUE NOT NULL
+  - created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%d %H:%M:%f','now'))
+  - updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%d %H:%M:%f','now'))
+  - index: lower(name)
+
+### Tag normalization rules
+- Trim leading/trailing whitespace
+- Remove leading '#'
+- Collapse internal whitespace to a single space
+- Lowercase for case-insensitive uniqueness
 
 ### Timestamp behavior
 - created_at defaults to the insertion time.
-- updated_at defaults to insertion time; application logic should explicitly update this column on write operations that modify a project. (No DB trigger is used to keep schema simple and follow repo style.)
+- updated_at defaults to insertion time; application logic should explicitly update this column on write operations that modify a project. (No DB trigger is used for projects; tags use a trigger to update updated_at on name change.)
 
 ### Rollbacks
 - The migration files are idempotent (CREATE TABLE/INDEX IF NOT EXISTS). To revert changes during development you can either delete the SQLite file (blobfishapp.sqlite) or manually run DROP statements for the affected tables and indices.

--- a/server/migrations/20250101010303_create_tags.sql
+++ b/server/migrations/20250101010303_create_tags.sql
@@ -1,0 +1,18 @@
+-- Create tags table with normalized unique names
+CREATE TABLE IF NOT EXISTS tags (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL UNIQUE,
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%d %H:%M:%f','now')),
+  updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%d %H:%M:%f','now'))
+);
+
+-- Case-insensitive search support
+CREATE INDEX IF NOT EXISTS idx_tags_name_lower ON tags(lower(name));
+
+-- updated_at trigger with millisecond precision
+CREATE TRIGGER IF NOT EXISTS tags_updated_at
+AFTER UPDATE OF name ON tags
+FOR EACH ROW
+BEGIN
+  UPDATE tags SET updated_at = (strftime('%Y-%m-%d %H:%M:%f','now')) WHERE id = NEW.id;
+END;

--- a/server/src/db/helpers.rs
+++ b/server/src/db/helpers.rs
@@ -1,5 +1,33 @@
 use sqlx::SqlitePool;
 
+/// Normalize a tag name according to database rules:
+/// - Trim leading/trailing whitespace
+/// - Strip all leading '#'
+/// - Collapse internal whitespace runs to a single space
+/// - Lowercase for deterministic, case-insensitive uniqueness
+pub fn normalize_tag_name<S: AsRef<str>>(name: S) -> String {
+    let mut s = name.as_ref().trim().to_string();
+    // Strip all leading '#'
+    while s.starts_with('#') {
+        s.remove(0);
+    }
+    // Collapse internal whitespace (any consecutive Unicode whitespace -> single ASCII space)
+    let mut collapsed = String::with_capacity(s.len());
+    let mut prev_space = false;
+    for ch in s.chars() {
+        if ch.is_whitespace() {
+            if !prev_space {
+                collapsed.push(' ');
+                prev_space = true;
+            }
+        } else {
+            collapsed.push(ch);
+            prev_space = false;
+        }
+    }
+    collapsed.trim().to_lowercase()
+}
+
 /// Fetch a single row and convert it to the specified type
 pub async fn fetch_one<T>(pool: &SqlitePool, sql: &str, args: &[&str]) -> Result<T, sqlx::Error>
 where
@@ -19,4 +47,32 @@ pub async fn execute(pool: &SqlitePool, sql: &str, args: &[&str]) -> Result<u64,
         query = query.bind(arg);
     }
     Ok(query.execute(pool).await?.rows_affected())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_tag_name;
+
+    #[test]
+    fn test_normalize_tag_name_basic() {
+        assert_eq!(normalize_tag_name("Work"), "work");
+        assert_eq!(normalize_tag_name("  Work  "), "work");
+        assert_eq!(normalize_tag_name("#Work"), "work");
+        assert_eq!(normalize_tag_name("##Work"), "work");
+        assert_eq!(normalize_tag_name("wOrK"), "work");
+    }
+
+    #[test]
+    fn test_normalize_tag_name_spaces() {
+        assert_eq!(normalize_tag_name("Foo   Bar"), "foo bar");
+        assert_eq!(normalize_tag_name("  Foo\t\tBar  "), "foo bar");
+        assert_eq!(normalize_tag_name("Foo\nBar"), "foo bar");
+    }
+
+    #[test]
+    fn test_normalize_tag_name_unicode_ws() {
+        // non-breaking space and em-space should collapse
+        let s = format!("Foo{}{}Bar", '\u{00A0}', '\u{2003}');
+        assert_eq!(normalize_tag_name(s), "foo bar");
+    }
 }

--- a/server/src/db/mod.rs
+++ b/server/src/db/mod.rs
@@ -8,6 +8,8 @@ pub mod helpers;
 
 #[cfg(test)]
 mod tests;
+#[cfg(test)]
+mod tests_tags;
 
 pub async fn init(db_path: &str) -> Result<SqlitePool, sqlx::Error> {
     tracing::info!("Initializing database at {}", db_path);

--- a/server/src/db/tests_tags.rs
+++ b/server/src/db/tests_tags.rs
@@ -1,0 +1,93 @@
+#[cfg(test)]
+mod db_tags_tests {
+    use sqlx::{sqlite::SqliteRow, Row};
+
+    use crate::db;
+    use crate::db::helpers::normalize_tag_name;
+
+    fn tmp_db_path() -> String {
+        format!("./tmp_rovodev_tags_test_{}.sqlite", uuid::Uuid::new_v4())
+    }
+
+    #[tokio::test]
+    async fn tags_table_enforces_uniqueness_on_normalized_values() {
+        let path = tmp_db_path();
+        let pool = db::init(&path).await.expect("db init");
+
+        // Helper to insert a tag
+        async fn insert_tag(pool: &sqlx::SqlitePool, name: &str) -> Result<(), sqlx::Error> {
+            let normalized = normalize_tag_name(name);
+            sqlx::query("INSERT INTO tags (id, name) VALUES (?, ?)")
+                .bind(uuid::Uuid::new_v4().to_string())
+                .bind(normalized)
+                .execute(pool)
+                .await?
+                .rows_affected();
+            Ok(())
+        }
+
+        insert_tag(&pool, "  #Work  ").await.unwrap();
+        // Different casings and extra spacing should normalize to same stored value
+        let dup_cases = ["work", "WoRk", "work  ", "##Work", "\tWork\n"]; // variations that normalize to "work"
+        for v in dup_cases {
+            let res = insert_tag(&pool, v).await;
+            assert!(res.is_err(), "expected uniqueness violation for value: {}", v);
+        }
+
+        // Verify the stored value is the normalized one
+        let row: SqliteRow = sqlx::query("SELECT name FROM tags LIMIT 1")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        let stored: String = row.get(0);
+        assert_eq!(stored, "work");
+
+        // Cleanup
+        drop(pool);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[tokio::test]
+    async fn tags_updated_at_changes_on_update() {
+        let path = tmp_db_path();
+        let pool = db::init(&path).await.expect("db init");
+        let id = uuid::Uuid::new_v4().to_string();
+        let now_row = sqlx::query("INSERT INTO tags (id, name) VALUES (?, ?)")
+            .bind(&id)
+            .bind(normalize_tag_name("#Home  Stuff"))
+            .execute(&pool)
+            .await
+            .unwrap();
+        assert_eq!(now_row.rows_affected(), 1);
+
+        let row1: (String, String) = sqlx::query_as("SELECT created_at, updated_at FROM tags WHERE id = ?")
+            .bind(&id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+
+        // Sleep a bit to ensure a timestamp change
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+        // Perform an update to trigger updated_at change (rename)
+        let _ = sqlx::query("UPDATE tags SET name = ? WHERE id = ?")
+            .bind(normalize_tag_name("home stuff 2"))
+            .bind(&id)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let row2: (String, String) = sqlx::query_as("SELECT created_at, updated_at FROM tags WHERE id = ?")
+            .bind(&id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+
+        assert_eq!(row1.0, row2.0, "created_at should remain unchanged");
+        assert_ne!(row1.1, row2.1, "updated_at should update on row change");
+
+        // Cleanup
+        drop(pool);
+        let _ = std::fs::remove_file(&path);
+    }
+}

--- a/todo-app-implementation-sequencing-plan.md
+++ b/todo-app-implementation-sequencing-plan.md
@@ -22,7 +22,7 @@ Note on a few tickets with soft/rolling dependencies
 Wave 1 — Foundations (independent kickoff)
 Backend
 - [x] .rovodev/todo-app-001_server_migrations_projects_memberships.md
-- [ ] .rovodev/todo-app-005_server_migrations_tags.md
+- [x] .rovodev/todo-app-005_server_migrations_tags.md
 - [x] .rovodev/todo-app-019_server_placeholder.md (reserved / gap filler)
 Shared
 - [ ] .rovodev/todo-app-051_shared_timezone_and_apollo.md (can start; finalize after 008,010)


### PR DESCRIPTION
Implements ticket .rovodev/todo-app-005_server_migrations_tags.md.

Summary
- Create tags table with normalized unique names
- Add helper normalization rules

Details
- Schema: tags(id, name UNIQUE, created_at, updated_at)
- Normalization: trim, collapse spaces, strip leading '#', lowercase for case-insensitive uniqueness
- Index: lower(name)
- Trigger: updated_at updates on name change (ms precision)

Tests
- Normalization and uniqueness
- updated_at trigger fires on name change

Docs
- DATABASE.md updated
- Implementation plan updated (ticket 005 checked)

Acceptance Criteria
- Colliding names normalize to the same stored value

Notes
- normalize_tag_name helper should be reused by Tags GraphQL CRUD (006)