### PR TITLE
045 — Mobile: Persist Last-Selected Project and View

### DIFF
--- a/mobileapp/app/_layout.tsx
+++ b/mobileapp/app/_layout.tsx
@@ -1,11 +1,14 @@
 import { AuthProvider } from '@shared/contexts/AuthContext';
 import App from '../src/App';
 import LocalStorage from '../src/LocalStorage';
+import { LastSelectionProvider } from '../src/contexts/LastSelectionContext';
 
 export default function RootLayout() {
   return (
     <AuthProvider storage={LocalStorage}>
-      <App />
+      <LastSelectionProvider>
+        <App />
+      </LastSelectionProvider>
     </AuthProvider>
   );
 }

--- a/mobileapp/src/App.tsx
+++ b/mobileapp/src/App.tsx
@@ -9,9 +9,12 @@ import selectMobileApp from './selectMobileApp';
 const HomePage = selectMobileApp();
 import LoginPage from './pages/LoginPage';
 
+import { useLastSelection } from './contexts/LastSelectionContext';
+
 type AppContentProps = { isAuthenticating: boolean; isLoggedIn: boolean };
 const AppContent = ({ isAuthenticating, isLoggedIn }: AppContentProps) => {
-  if (isAuthenticating) {
+  const { isRestoring } = useLastSelection();
+  if (isAuthenticating || isRestoring) {
     return <GlobalLoading />;
   } else if (isLoggedIn) {
     return <HomePage />;

--- a/mobileapp/src/components/GlobalLoading.tsx
+++ b/mobileapp/src/components/GlobalLoading.tsx
@@ -7,7 +7,7 @@ const GlobalLoading = () => {
       <View style={styles.container}>
         <View style={styles.content}>
           <ActivityIndicator animating={true} size="large" />
-          <Text style={styles.text}>Authenticating...</Text>
+          <Text style={styles.text}>Loading...</Text>
         </View>
       </View>
     </Modal>

--- a/mobileapp/src/contexts/LastSelectionContext.tsx
+++ b/mobileapp/src/contexts/LastSelectionContext.tsx
@@ -1,0 +1,102 @@
+import React, { createContext, useContext, useEffect, useMemo, useState } from 'react';
+import type { ReactNode } from 'react';
+import LocalStorage from '../LocalStorage';
+import {
+  getLastSavedViewId as storageGetLastSavedViewId,
+  getLastSelectedProjectId as storageGetLastSelectedProjectId,
+  removeLastSavedViewId as storageRemoveLastSavedViewId,
+  removeLastSelectedProjectId as storageRemoveLastSelectedProjectId,
+  setLastSavedViewId as storageSetLastSavedViewId,
+  setLastSelectedProjectId as storageSetLastSelectedProjectId,
+} from '@shared/storage/keys';
+
+export type LastSelectionState = {
+  lastProjectId: string | null;
+  lastSavedViewId: string | null;
+  isRestoring: boolean;
+};
+
+export type LastSelectionContextType = LastSelectionState & {
+  setLastProjectId: (projectId: string | null) => Promise<void>;
+  setLastSavedViewId: (savedViewId: string | null) => Promise<void>;
+  clear: () => Promise<void>;
+};
+
+const LastSelectionContext = createContext<LastSelectionContextType | null>(null);
+
+export function LastSelectionProvider({ children }: { children: ReactNode }) {
+  const [state, setState] = useState<LastSelectionState>({ lastProjectId: null, lastSavedViewId: null, isRestoring: true });
+
+  useEffect(() => {
+    let mounted = true;
+
+    (async () => {
+      try {
+        const [projectId, savedViewId] = await Promise.all([
+          storageGetLastSelectedProjectId(LocalStorage),
+          storageGetLastSavedViewId(LocalStorage),
+        ]);
+        if (!mounted) return;
+        setState({ lastProjectId: projectId, lastSavedViewId: savedViewId, isRestoring: false });
+      } catch (e) {
+        if (__DEV__) console.warn('Failed to restore last selection', e);
+        if (mounted) setState((s) => ({ ...s, isRestoring: false }));
+      }
+    })();
+
+    return () => { mounted = false; };
+  }, []);
+
+  const api = useMemo<LastSelectionContextType>(() => ({
+    ...state,
+    setLastProjectId: async (projectId: string | null) => {
+      try {
+        if (projectId === null) {
+          await storageRemoveLastSelectedProjectId(LocalStorage);
+        } else {
+          await storageSetLastSelectedProjectId(LocalStorage, projectId);
+        }
+        setState((prev) => ({ ...prev, lastProjectId: projectId }));
+      } catch (e) {
+        if (__DEV__) console.warn('Failed to set last project id', e);
+      }
+    },
+    setLastSavedViewId: async (savedViewId: string | null) => {
+      try {
+        if (savedViewId === null) {
+          await storageRemoveLastSavedViewId(LocalStorage);
+        } else {
+          await storageSetLastSavedViewId(LocalStorage, savedViewId);
+        }
+        setState((prev) => ({ ...prev, lastSavedViewId: savedViewId }));
+      } catch (e) {
+        if (__DEV__) console.warn('Failed to set last saved view id', e);
+      }
+    },
+    clear: async () => {
+      try {
+        await Promise.all([
+          storageRemoveLastSelectedProjectId(LocalStorage),
+          storageRemoveLastSavedViewId(LocalStorage),
+        ]);
+        setState({ lastProjectId: null, lastSavedViewId: null, isRestoring: false });
+      } catch (e) {
+        if (__DEV__) console.warn('Failed to clear last selection', e);
+      }
+    },
+  }), [state]);
+
+  return (
+    <LastSelectionContext.Provider value={api}>
+      {children}
+    </LastSelectionContext.Provider>
+  );
+}
+
+export function useLastSelection(): LastSelectionContextType {
+  const ctx = useContext(LastSelectionContext);
+  if (!ctx) {
+    throw new Error('useLastSelection must be used within a LastSelectionProvider');
+  }
+  return ctx;
+}

--- a/todo-app-implementation-sequencing-plan.md
+++ b/todo-app-implementation-sequencing-plan.md
@@ -45,7 +45,7 @@ Backend
 Mobile
 - [ ] .rovodev/todo-app-031_mobile_app_wiring_selector_app_config.md (depends on 030)
 - [ ] .rovodev/todo-app-044_mobile_timezone_plumbing.md (depends on 051)
-- [ ] .rovodev/todo-app-045_mobile_persist_last_selected_project_view.md (depends on 052)
+- [x] .rovodev/todo-app-045_mobile_persist_last_selected_project_view.md (depends on 052)
 
 Next up when Wave 2 items complete:
 - Project mutations and permissions (003,004)


### PR DESCRIPTION
Implement persistence and restoration of last-selected project and saved view in the mobile app.

Changes:
- Add LastSelectionContext provider to restore and manage last selections
- Wrap app with LastSelectionProvider in mobileapp/app/_layout.tsx
- Show loading gate during restore in mobileapp/src/App.tsx (uses isRestoring)
- Update GlobalLoading text to generic 'Loading...'
- Mark ticket done in todo-app-implementation-sequencing-plan.md

Notes:
- Storage helpers are defined in shared/storage/keys.ts
- This integrates cleanly with upcoming Projects (033) and Saved Views (040) work for routing and applying views