### PR TITLE
011 — Server: Migrations for Saved Views and Project Default View

### DIFF
--- a/server/DATABASE.md
+++ b/server/DATABASE.md
@@ -63,6 +63,19 @@ Database migrations are applied automatically on server startup. The server conn
   - tag_id TEXT NOT NULL (FK tags.id) ON DELETE CASCADE
   - indices: series_id, tag_id
   - unique(series_id, tag_id)
+- saved_views
+  - id TEXT PRIMARY KEY
+  - project_id TEXT NOT NULL (FK projects.id)
+  - name TEXT NOT NULL
+  - filters TEXT NOT NULL (JSON string)
+  - created_by TEXT NOT NULL (FK users.id)
+  - created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+  - updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+  - indices: project_id
+  - unique(project_id, LOWER(TRIM(name))) for case-insensitive name uniqueness per project
+- project_default_view
+  - project_id TEXT PRIMARY KEY (FK projects.id)
+  - saved_view_id TEXT NULL (FK saved_views.id)
 
 ### Tag normalization rules
 - Trim leading/trailing whitespace

--- a/server/migrations/20250101010505_create_saved_views.sql
+++ b/server/migrations/20250101010505_create_saved_views.sql
@@ -1,0 +1,23 @@
+CREATE TABLE IF NOT EXISTS saved_views (
+  id TEXT PRIMARY KEY,
+  project_id TEXT NOT NULL,
+  name TEXT NOT NULL,
+  filters TEXT NOT NULL, -- JSON string
+  created_by TEXT NOT NULL,
+  created_at DATETIME NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+  updated_at DATETIME NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+  FOREIGN KEY(project_id) REFERENCES projects(id),
+  FOREIGN KEY(created_by) REFERENCES users(id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_saved_views_project_id ON saved_views(project_id);
+
+-- Ensure unique name per project (case-insensitive)
+CREATE UNIQUE INDEX IF NOT EXISTS idx_saved_views_project_name_unique ON saved_views(project_id, LOWER(TRIM(name)));
+
+CREATE TABLE IF NOT EXISTS project_default_view (
+  project_id TEXT PRIMARY KEY,
+  saved_view_id TEXT,
+  FOREIGN KEY(project_id) REFERENCES projects(id),
+  FOREIGN KEY(saved_view_id) REFERENCES saved_views(id)
+);

--- a/todo-app-implementation-sequencing-plan.md
+++ b/todo-app-implementation-sequencing-plan.md
@@ -40,7 +40,7 @@ Backend
 - [x] .rovodev/todo-app-002_server_graphql_projects_queries.md (depends on 001)
 - [ ] .rovodev/todo-app-006_server_graphql_tags_crud.md (depends on 005)
 - [x] .rovodev/todo-app-007_server_migrations_tasks_task_tags.md (depends on 001,005)
-- [ ] .rovodev/todo-app-011_server_migrations_saved_views.md (depends on 001)
+- [x] .rovodev/todo-app-011_server_migrations_saved_views.md (depends on 001)
 - [x] .rovodev/todo-app-013_server_migrations_recurring_series.md (depends on 001,005)
 Mobile
 - [x] .rovodev/todo-app-031_mobile_app_wiring_selector_app_config.md (depends on 030)


### PR DESCRIPTION
- Added migration 20250101010505_create_saved_views.sql with:
  - saved_views table (id, project_id, name, filters JSON, created_by, timestamps)
  - project_default_view table (project_id, saved_view_id nullable FK)
  - Unique constraint per project on case-insensitive name
  - Proper indices for project_id lookups
- Updated DATABASE.md with new table schemas and constraints
- Marked ticket as complete in todo-app-implementation-sequencing-plan.md

Implements spec requirements from §§5,7,8 for saved views functionality.