### PR TITLE
todo-app: 012 — Server: GraphQL Saved Views CRUD and Default Setter

### DIFF
--- a/server/src/auth/guard.rs
+++ b/server/src/auth/guard.rs
@@ -129,11 +129,12 @@ mod tests {
             .unwrap()
             .create_if_missing(true)
             .foreign_keys(true);
-        
+
         let pool = SqlitePool::connect_with(options).await.unwrap();
-        
+
         // Create tables manually to avoid migration conflicts
-        sqlx::query(r#"
+        sqlx::query(
+            r#"
             CREATE TABLE users (
                 id TEXT PRIMARY KEY,
                 username TEXT UNIQUE NOT NULL,
@@ -142,9 +143,14 @@ mod tests {
                 created_at TEXT DEFAULT CURRENT_TIMESTAMP,
                 updated_at TEXT DEFAULT CURRENT_TIMESTAMP
             )
-        "#).execute(&pool).await.unwrap();
-        
-        sqlx::query(r#"
+        "#,
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        sqlx::query(
+            r#"
             CREATE TABLE projects (
                 id TEXT PRIMARY KEY,
                 name TEXT NOT NULL,
@@ -154,9 +160,14 @@ mod tests {
                 updated_at TEXT DEFAULT CURRENT_TIMESTAMP,
                 FOREIGN KEY (owner_id) REFERENCES users(id)
             )
-        "#).execute(&pool).await.unwrap();
-        
-        sqlx::query(r#"
+        "#,
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        sqlx::query(
+            r#"
             CREATE TABLE project_members (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 project_id TEXT NOT NULL,
@@ -166,8 +177,12 @@ mod tests {
                 FOREIGN KEY (project_id) REFERENCES projects(id),
                 FOREIGN KEY (user_id) REFERENCES users(id)
             )
-        "#).execute(&pool).await.unwrap();
-        
+        "#,
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
         pool
     }
 

--- a/server/src/graphql/auth.rs
+++ b/server/src/graphql/auth.rs
@@ -888,6 +888,425 @@ impl AuthenticatedMutation {
             default_tag_ids,
         })
     }
+
+    async fn create_saved_view(
+        &self,
+        ctx: &Context<'_>,
+        project_id: String,
+        name: String,
+        filters: crate::graphql::SavedViewFiltersInput,
+    ) -> async_graphql::Result<crate::graphql::SavedView> {
+        use crate::db::helpers::normalize_project_name; // Reuse for general name normalization
+        use crate::graphql::{SavedView, SavedViewFilters};
+
+        // Require authentication
+        let claims = match ctx.data_opt::<Arc<Claims>>() {
+            Some(claims) => claims,
+            None => {
+                return Err(async_graphql::Error::new("Authentication required"));
+            }
+        };
+
+        let pool = ctx.data::<SqlitePool>()?;
+
+        // Get user ID
+        let user_id = sqlx::query_as::<_, (String,)>("SELECT id FROM users WHERE username = ?1")
+            .bind(&claims.sub)
+            .fetch_one(pool)
+            .await?
+            .0;
+
+        // Check if user has access to this project
+        require_member(pool, &user_id, &project_id).await?;
+
+        // Validate and normalize name
+        let normalized_name = normalize_project_name(&name); // Reuse existing normalization
+        if normalized_name.is_empty() {
+            let error = async_graphql::Error::new("Saved view name cannot be empty")
+                .extend_with(|_, e| e.set("code", ErrorCode::ValidationFailed.as_str()));
+            return Err(error);
+        }
+
+        if normalized_name.len() > 60 {
+            let error = async_graphql::Error::new("Saved view name cannot exceed 60 characters")
+                .extend_with(|_, e| e.set("code", ErrorCode::ValidationFailed.as_str()));
+            return Err(error);
+        }
+
+        // Check for unique name per project (case-insensitive)
+        let existing_count = sqlx::query_as::<_, (i64,)>(
+            "SELECT COUNT(*) FROM saved_views WHERE project_id = ?1 AND LOWER(TRIM(name)) = LOWER(TRIM(?2))"
+        )
+        .bind(&project_id)
+        .bind(&normalized_name)
+        .fetch_one(pool)
+        .await?;
+
+        if existing_count.0 > 0 {
+            let error = async_graphql::Error::new(
+                "A saved view with this name already exists in this project",
+            )
+            .extend_with(|_, e| e.set("code", ErrorCode::ValidationFailed.as_str()));
+            return Err(error);
+        }
+
+        // Validate assignee exists if provided
+        if let Some(ref assignee_id) = filters.assignee {
+            let assignee_exists =
+                sqlx::query_as::<_, (i64,)>("SELECT COUNT(*) FROM users WHERE id = ?1")
+                    .bind(assignee_id)
+                    .fetch_one(pool)
+                    .await?;
+
+            if assignee_exists.0 == 0 {
+                let error = async_graphql::Error::new("Assignee not found")
+                    .extend_with(|_, e| e.set("code", ErrorCode::NotFound.as_str()));
+                return Err(error);
+            }
+        }
+
+        // Validate tag IDs exist
+        for tag_id in &filters.tag_ids {
+            let tag_exists = sqlx::query_as::<_, (i64,)>("SELECT COUNT(*) FROM tags WHERE id = ?1")
+                .bind(tag_id)
+                .fetch_one(pool)
+                .await?;
+
+            if tag_exists.0 == 0 {
+                let error = async_graphql::Error::new("One or more tags not found")
+                    .extend_with(|_, e| e.set("code", ErrorCode::NotFound.as_str()));
+                return Err(error);
+            }
+        }
+
+        // Convert input filters to JSON
+        let filters_obj = SavedViewFilters {
+            statuses: filters.statuses,
+            assignee: filters.assignee,
+            include_unassigned: filters.include_unassigned,
+            assigned_to_me: filters.assigned_to_me,
+            tag_ids: filters.tag_ids,
+        };
+
+        let filters_json = serde_json::to_string(&filters_obj).map_err(|_| {
+            async_graphql::Error::new("Failed to serialize filters")
+                .extend_with(|_, e| e.set("code", ErrorCode::Internal.as_str()))
+        })?;
+
+        // Create the saved view
+        let id = uuid::Uuid::new_v4().to_string();
+        sqlx::query(
+            "INSERT INTO saved_views (id, project_id, name, filters, created_by) VALUES (?1, ?2, ?3, ?4, ?5)"
+        )
+        .bind(&id)
+        .bind(&project_id)
+        .bind(&normalized_name)
+        .bind(&filters_json)
+        .bind(&user_id)
+        .execute(pool)
+        .await?;
+
+        // Fetch the created saved view
+        let saved_view = sqlx::query_as::<_, (String, String, String, String, String, String, String)>(
+            "SELECT id, project_id, name, filters, created_by, created_at, updated_at FROM saved_views WHERE id = ?1"
+        )
+        .bind(&id)
+        .fetch_one(pool)
+        .await?;
+
+        Ok(SavedView {
+            id: saved_view.0,
+            project_id: saved_view.1,
+            name: saved_view.2,
+            filters: filters_obj,
+            created_by: saved_view.4,
+            created_at: saved_view.5,
+            updated_at: saved_view.6,
+        })
+    }
+
+    async fn update_saved_view(
+        &self,
+        ctx: &Context<'_>,
+        id: String,
+        name: Option<String>,
+        filters: Option<crate::graphql::SavedViewFiltersInput>,
+        last_known_updated_at: String,
+    ) -> async_graphql::Result<crate::graphql::SavedView> {
+        use crate::db::helpers::normalize_project_name;
+        use crate::graphql::{SavedView, SavedViewFilters};
+
+        // Require authentication
+        let claims = match ctx.data_opt::<Arc<Claims>>() {
+            Some(claims) => claims,
+            None => {
+                return Err(async_graphql::Error::new("Authentication required"));
+            }
+        };
+
+        let pool = ctx.data::<SqlitePool>()?;
+
+        // Get user ID
+        let user_id = sqlx::query_as::<_, (String,)>("SELECT id FROM users WHERE username = ?1")
+            .bind(&claims.sub)
+            .fetch_one(pool)
+            .await?
+            .0;
+
+        // Get current saved view
+        let current = sqlx::query_as::<_, (String, String, String, String, String, String, String)>(
+            "SELECT id, project_id, name, filters, created_by, created_at, updated_at FROM saved_views WHERE id = ?1"
+        )
+        .bind(&id)
+        .fetch_one(pool)
+        .await
+        .map_err(|_| {
+            async_graphql::Error::new("Saved view not found")
+                .extend_with(|_, e| e.set("code", ErrorCode::NotFound.as_str()))
+        })?;
+
+        // Check if user has access to this project
+        require_member(pool, &user_id, &current.1).await?;
+
+        // Check for stale write
+        if current.6 != last_known_updated_at {
+            let error = async_graphql::Error::new("Saved view has been modified by another user")
+                .extend_with(|_, e| e.set("code", ErrorCode::ConflictStaleWrite.as_str()));
+            return Err(error);
+        }
+
+        // Prepare updated values
+        let updated_name = if let Some(name) = name {
+            let normalized_name = normalize_project_name(&name);
+            if normalized_name.is_empty() {
+                let error = async_graphql::Error::new("Saved view name cannot be empty")
+                    .extend_with(|_, e| e.set("code", ErrorCode::ValidationFailed.as_str()));
+                return Err(error);
+            }
+
+            if normalized_name.len() > 60 {
+                let error =
+                    async_graphql::Error::new("Saved view name cannot exceed 60 characters")
+                        .extend_with(|_, e| e.set("code", ErrorCode::ValidationFailed.as_str()));
+                return Err(error);
+            }
+
+            // Check for unique name per project (case-insensitive), excluding current view
+            let existing_count = sqlx::query_as::<_, (i64,)>(
+                "SELECT COUNT(*) FROM saved_views WHERE project_id = ?1 AND LOWER(TRIM(name)) = LOWER(TRIM(?2)) AND id != ?3"
+            )
+            .bind(&current.1)
+            .bind(&normalized_name)
+            .bind(&id)
+            .fetch_one(pool)
+            .await?;
+
+            if existing_count.0 > 0 {
+                let error = async_graphql::Error::new(
+                    "A saved view with this name already exists in this project",
+                )
+                .extend_with(|_, e| e.set("code", ErrorCode::ValidationFailed.as_str()));
+                return Err(error);
+            }
+
+            normalized_name
+        } else {
+            current.2.clone()
+        };
+
+        let updated_filters_json = if let Some(filters) = filters {
+            // Validate assignee exists if provided
+            if let Some(ref assignee_id) = filters.assignee {
+                let assignee_exists =
+                    sqlx::query_as::<_, (i64,)>("SELECT COUNT(*) FROM users WHERE id = ?1")
+                        .bind(assignee_id)
+                        .fetch_one(pool)
+                        .await?;
+
+                if assignee_exists.0 == 0 {
+                    let error = async_graphql::Error::new("Assignee not found")
+                        .extend_with(|_, e| e.set("code", ErrorCode::NotFound.as_str()));
+                    return Err(error);
+                }
+            }
+
+            // Validate tag IDs exist
+            for tag_id in &filters.tag_ids {
+                let tag_exists =
+                    sqlx::query_as::<_, (i64,)>("SELECT COUNT(*) FROM tags WHERE id = ?1")
+                        .bind(tag_id)
+                        .fetch_one(pool)
+                        .await?;
+
+                if tag_exists.0 == 0 {
+                    let error = async_graphql::Error::new("One or more tags not found")
+                        .extend_with(|_, e| e.set("code", ErrorCode::NotFound.as_str()));
+                    return Err(error);
+                }
+            }
+
+            let filters_obj = SavedViewFilters {
+                statuses: filters.statuses,
+                assignee: filters.assignee,
+                include_unassigned: filters.include_unassigned,
+                assigned_to_me: filters.assigned_to_me,
+                tag_ids: filters.tag_ids,
+            };
+
+            serde_json::to_string(&filters_obj).map_err(|_| {
+                async_graphql::Error::new("Failed to serialize filters")
+                    .extend_with(|_, e| e.set("code", ErrorCode::Internal.as_str()))
+            })?
+        } else {
+            current.3.clone()
+        };
+
+        // Update the saved view
+        sqlx::query(
+            "UPDATE saved_views SET name = ?1, filters = ?2, updated_at = CURRENT_TIMESTAMP WHERE id = ?3"
+        )
+        .bind(&updated_name)
+        .bind(&updated_filters_json)
+        .bind(&id)
+        .execute(pool)
+        .await?;
+
+        // Fetch updated saved view
+        let updated = sqlx::query_as::<_, (String, String, String, String, String, String, String)>(
+            "SELECT id, project_id, name, filters, created_by, created_at, updated_at FROM saved_views WHERE id = ?1"
+        )
+        .bind(&id)
+        .fetch_one(pool)
+        .await?;
+
+        let filters: SavedViewFilters = serde_json::from_str(&updated.3).map_err(|_| {
+            async_graphql::Error::new("Invalid saved view filters")
+                .extend_with(|_, e| e.set("code", ErrorCode::Internal.as_str()))
+        })?;
+
+        Ok(SavedView {
+            id: updated.0,
+            project_id: updated.1,
+            name: updated.2,
+            filters,
+            created_by: updated.4,
+            created_at: updated.5,
+            updated_at: updated.6,
+        })
+    }
+
+    async fn delete_saved_view(
+        &self,
+        ctx: &Context<'_>,
+        id: String,
+    ) -> async_graphql::Result<bool> {
+        // Require authentication
+        let claims = match ctx.data_opt::<Arc<Claims>>() {
+            Some(claims) => claims,
+            None => {
+                return Err(async_graphql::Error::new("Authentication required"));
+            }
+        };
+
+        let pool = ctx.data::<SqlitePool>()?;
+
+        // Get user ID
+        let user_id = sqlx::query_as::<_, (String,)>("SELECT id FROM users WHERE username = ?1")
+            .bind(&claims.sub)
+            .fetch_one(pool)
+            .await?
+            .0;
+
+        // Get saved view to check project access
+        let saved_view = sqlx::query_as::<_, (String, String)>(
+            "SELECT id, project_id FROM saved_views WHERE id = ?1",
+        )
+        .bind(&id)
+        .fetch_one(pool)
+        .await
+        .map_err(|_| {
+            async_graphql::Error::new("Saved view not found")
+                .extend_with(|_, e| e.set("code", ErrorCode::NotFound.as_str()))
+        })?;
+
+        // Check if user has access to this project
+        require_member(pool, &user_id, &saved_view.1).await?;
+
+        // Remove from default view if it's set as default
+        sqlx::query("DELETE FROM project_default_view WHERE saved_view_id = ?1")
+            .bind(&id)
+            .execute(pool)
+            .await?;
+
+        // Delete the saved view
+        let result = sqlx::query("DELETE FROM saved_views WHERE id = ?1")
+            .bind(&id)
+            .execute(pool)
+            .await?;
+
+        Ok(result.rows_affected() > 0)
+    }
+
+    async fn set_project_default_saved_view(
+        &self,
+        ctx: &Context<'_>,
+        project_id: String,
+        saved_view_id: Option<String>,
+    ) -> async_graphql::Result<bool> {
+        // Require authentication
+        let claims = match ctx.data_opt::<Arc<Claims>>() {
+            Some(claims) => claims,
+            None => {
+                return Err(async_graphql::Error::new("Authentication required"));
+            }
+        };
+
+        let pool = ctx.data::<SqlitePool>()?;
+
+        // Get user ID
+        let user_id = sqlx::query_as::<_, (String,)>("SELECT id FROM users WHERE username = ?1")
+            .bind(&claims.sub)
+            .fetch_one(pool)
+            .await?
+            .0;
+
+        // Check if user has access to this project
+        require_member(pool, &user_id, &project_id).await?;
+
+        if let Some(view_id) = saved_view_id {
+            // Validate that the saved view exists and belongs to this project
+            let view_exists = sqlx::query_as::<_, (i64,)>(
+                "SELECT COUNT(*) FROM saved_views WHERE id = ?1 AND project_id = ?2",
+            )
+            .bind(&view_id)
+            .bind(&project_id)
+            .fetch_one(pool)
+            .await?;
+
+            if view_exists.0 == 0 {
+                let error = async_graphql::Error::new("Saved view not found in this project")
+                    .extend_with(|_, e| e.set("code", ErrorCode::NotFound.as_str()));
+                return Err(error);
+            }
+
+            // Set or update the default view
+            sqlx::query(
+                "INSERT OR REPLACE INTO project_default_view (project_id, saved_view_id) VALUES (?1, ?2)"
+            )
+            .bind(&project_id)
+            .bind(&view_id)
+            .execute(pool)
+            .await?;
+        } else {
+            // Clear the default view
+            sqlx::query("DELETE FROM project_default_view WHERE project_id = ?1")
+                .bind(&project_id)
+                .execute(pool)
+                .await?;
+        }
+
+        Ok(true)
+    }
 }
 
 #[derive(InputObject)]

--- a/server/src/graphql/mod.rs
+++ b/server/src/graphql/mod.rs
@@ -2,10 +2,12 @@ use sqlx::{Row, SqlitePool};
 mod auth;
 mod tests_history;
 mod tests_recurring_series;
+mod tests_saved_views;
 
 pub use crate::graphql::auth::{AuthenticatedMutation, UnauthenticatedMutation};
 use async_graphql::{Context, EmptySubscription, Schema};
-use async_graphql::{MergedObject, Object, SimpleObject};
+use async_graphql::{InputObject, MergedObject, Object, SimpleObject};
+use serde::{Deserialize, Serialize};
 
 use crate::auth::Claims;
 use crate::auth::guard::require_member;
@@ -48,6 +50,48 @@ pub struct PagedTasks {
     items: Vec<Task>,
     #[graphql(name = "totalCount")]
     total_count: i32,
+}
+
+#[derive(SimpleObject)]
+pub struct SavedView {
+    id: String,
+    #[graphql(name = "projectId")]
+    project_id: String,
+    name: String,
+    filters: SavedViewFilters,
+    #[graphql(name = "createdBy")]
+    created_by: String,
+    #[graphql(name = "createdAt")]
+    created_at: String,
+    #[graphql(name = "updatedAt")]
+    updated_at: String,
+}
+
+#[derive(SimpleObject, Serialize, Deserialize)]
+pub struct SavedViewFilters {
+    statuses: Vec<TaskStatus>,
+    assignee: Option<String>,
+    #[graphql(name = "includeUnassigned")]
+    #[serde(rename = "includeUnassigned")]
+    include_unassigned: bool,
+    #[graphql(name = "assignedToMe")]
+    #[serde(rename = "assignedToMe")]
+    assigned_to_me: bool,
+    #[graphql(name = "tagIds")]
+    #[serde(rename = "tagIds")]
+    tag_ids: Vec<String>,
+}
+
+#[derive(InputObject)]
+pub struct SavedViewFiltersInput {
+    statuses: Vec<TaskStatus>,
+    assignee: Option<String>,
+    #[graphql(name = "includeUnassigned")]
+    include_unassigned: bool,
+    #[graphql(name = "assignedToMe")]
+    assigned_to_me: bool,
+    #[graphql(name = "tagIds")]
+    tag_ids: Vec<String>,
 }
 
 // Define a query root
@@ -678,6 +722,141 @@ impl QueryRoot {
             items: tasks,
             total_count: total_count as i32,
         })
+    }
+
+    async fn saved_views(
+        &self,
+        ctx: &Context<'_>,
+        project_id: String,
+    ) -> async_graphql::Result<Vec<SavedView>> {
+        let claims = match ctx.data_opt::<Arc<Claims>>() {
+            Some(claims) => claims,
+            None => {
+                return Err(async_graphql::Error::new("Authentication required"));
+            }
+        };
+
+        let pool = ctx.data::<SqlitePool>()?;
+        let username = &claims.sub;
+
+        // Get user ID
+        let user_id = sqlx::query_as::<_, (String,)>("SELECT id FROM users WHERE username = ?1")
+            .bind(username)
+            .fetch_one(pool)
+            .await?
+            .0;
+
+        // Check if user has access to this project
+        require_member(pool, &user_id, &project_id).await?;
+
+        // Fetch saved views for the project
+        let rows = sqlx::query(
+            "SELECT id, project_id, name, filters, created_by, created_at, updated_at 
+             FROM saved_views 
+             WHERE project_id = ?1 
+             ORDER BY name",
+        )
+        .bind(&project_id)
+        .fetch_all(pool)
+        .await?;
+
+        let mut saved_views = Vec::new();
+        for row in rows {
+            let id: String = row.get("id");
+            let project_id: String = row.get("project_id");
+            let name: String = row.get("name");
+            let filters_json: String = row.get("filters");
+            let created_by: String = row.get("created_by");
+            let created_at: String = row.get("created_at");
+            let updated_at: String = row.get("updated_at");
+
+            // Parse filters from JSON
+            let filters: SavedViewFilters = match serde_json::from_str(&filters_json) {
+                Ok(filters) => filters,
+                Err(_) => {
+                    return Err(async_graphql::Error::new("Invalid saved view filters"));
+                }
+            };
+
+            saved_views.push(SavedView {
+                id,
+                project_id,
+                name,
+                filters,
+                created_by,
+                created_at,
+                updated_at,
+            });
+        }
+
+        Ok(saved_views)
+    }
+
+    async fn project_default_saved_view(
+        &self,
+        ctx: &Context<'_>,
+        project_id: String,
+    ) -> async_graphql::Result<Option<SavedView>> {
+        let claims = match ctx.data_opt::<Arc<Claims>>() {
+            Some(claims) => claims,
+            None => {
+                return Err(async_graphql::Error::new("Authentication required"));
+            }
+        };
+
+        let pool = ctx.data::<SqlitePool>()?;
+        let username = &claims.sub;
+
+        // Get user ID
+        let user_id = sqlx::query_as::<_, (String,)>("SELECT id FROM users WHERE username = ?1")
+            .bind(username)
+            .fetch_one(pool)
+            .await?
+            .0;
+
+        // Check if user has access to this project
+        require_member(pool, &user_id, &project_id).await?;
+
+        // Fetch default saved view for the project
+        let row_result = sqlx::query(
+            "SELECT sv.id, sv.project_id, sv.name, sv.filters, sv.created_by, sv.created_at, sv.updated_at 
+             FROM saved_views sv
+             INNER JOIN project_default_view pdv ON sv.id = pdv.saved_view_id
+             WHERE pdv.project_id = ?1"
+        )
+        .bind(&project_id)
+        .fetch_optional(pool)
+        .await?;
+
+        if let Some(row) = row_result {
+            let id: String = row.get("id");
+            let project_id: String = row.get("project_id");
+            let name: String = row.get("name");
+            let filters_json: String = row.get("filters");
+            let created_by: String = row.get("created_by");
+            let created_at: String = row.get("created_at");
+            let updated_at: String = row.get("updated_at");
+
+            // Parse filters from JSON
+            let filters: SavedViewFilters = match serde_json::from_str(&filters_json) {
+                Ok(filters) => filters,
+                Err(_) => {
+                    return Err(async_graphql::Error::new("Invalid saved view filters"));
+                }
+            };
+
+            Ok(Some(SavedView {
+                id,
+                project_id,
+                name,
+                filters,
+                created_by,
+                created_at,
+                updated_at,
+            }))
+        } else {
+            Ok(None)
+        }
     }
 }
 

--- a/server/src/graphql/tests_saved_views.rs
+++ b/server/src/graphql/tests_saved_views.rs
@@ -1,0 +1,53 @@
+#[cfg(test)]
+mod tests {
+    use crate::graphql::{SavedViewFilters, SavedViewFiltersInput};
+    use crate::tasks::TaskStatus;
+    use serde_json;
+
+    #[test]
+    fn test_saved_view_filters_serialization() {
+        let filters = SavedViewFilters {
+            statuses: vec![TaskStatus::Todo, TaskStatus::Done],
+            assignee: Some("user123".to_string()),
+            include_unassigned: false,
+            assigned_to_me: true,
+            tag_ids: vec!["tag1".to_string(), "tag2".to_string()],
+        };
+
+        // Test serialization
+        let json = serde_json::to_string(&filters).expect("Should serialize");
+
+        // Test deserialization
+        let parsed: SavedViewFilters = serde_json::from_str(&json).expect("Should deserialize");
+
+        // Verify round-trip
+        assert_eq!(parsed.statuses.len(), 2);
+        assert_eq!(parsed.assignee, Some("user123".to_string()));
+        assert_eq!(parsed.include_unassigned, false);
+        assert_eq!(parsed.assigned_to_me, true);
+        assert_eq!(parsed.tag_ids.len(), 2);
+    }
+
+    #[test]
+    fn test_task_status_serialization() {
+        // Test each status value serializes correctly
+        let todo_json = serde_json::to_string(&TaskStatus::Todo).expect("Should serialize Todo");
+        let done_json = serde_json::to_string(&TaskStatus::Done).expect("Should serialize Done");
+        let abandoned_json =
+            serde_json::to_string(&TaskStatus::Abandoned).expect("Should serialize Abandoned");
+
+        assert_eq!(todo_json, "\"todo\"");
+        assert_eq!(done_json, "\"done\"");
+        assert_eq!(abandoned_json, "\"abandoned\"");
+
+        // Test deserialization
+        let todo: TaskStatus = serde_json::from_str("\"todo\"").expect("Should deserialize todo");
+        let done: TaskStatus = serde_json::from_str("\"done\"").expect("Should deserialize done");
+        let abandoned: TaskStatus =
+            serde_json::from_str("\"abandoned\"").expect("Should deserialize abandoned");
+
+        assert_eq!(todo, TaskStatus::Todo);
+        assert_eq!(done, TaskStatus::Done);
+        assert_eq!(abandoned, TaskStatus::Abandoned);
+    }
+}

--- a/server/src/tasks/mod.rs
+++ b/server/src/tasks/mod.rs
@@ -1,11 +1,15 @@
 use async_graphql::{Enum, SimpleObject};
 use chrono::{DateTime, NaiveDate, NaiveTime, TimeZone, Utc};
 use chrono_tz::Tz;
+use serde::{Deserialize, Serialize};
 
-#[derive(Enum, Copy, Clone, Eq, PartialEq, Debug)]
+#[derive(Enum, Copy, Clone, Eq, PartialEq, Debug, Serialize, Deserialize)]
 pub enum TaskStatus {
+    #[serde(rename = "todo")]
     Todo,
+    #[serde(rename = "done")]
     Done,
+    #[serde(rename = "abandoned")]
     Abandoned,
 }
 

--- a/todo-app-implementation-sequencing-plan.md
+++ b/todo-app-implementation-sequencing-plan.md
@@ -81,7 +81,7 @@ Next up when Wave 4 items complete:
 Wave 5 — Mutations and saved views
 Backend
 - [ ] .rovodev/todo-app-009_server_graphql_tasks_mutations.md (depends on 008)
-- [ ] .rovodev/todo-app-012_server_graphql_saved_views.md (depends on 011,004)
+- [x] .rovodev/todo-app-012_server_graphql_saved_views.md (depends on 011,004)
 - [ ] .rovodev/todo-app-021_server_tests_integration.md (depends on 010,018)
 
 Next up when Wave 5 items complete:


### PR DESCRIPTION
## Summary
Implements complete GraphQL CRUD operations for Saved Views with project-wide default view management.

## Changes Made
- **GraphQL Types**: Added SavedView and SavedViewFilters types with proper serde serialization
- **Queries**: Implemented savedViews(projectId) and projectDefaultSavedView(projectId)
- **Mutations**: Added createSavedView, updateSavedView, deleteSavedView, and setProjectDefaultSavedView
- **Validation**: Enforced unique name per project (case-insensitive), input validation for filters
- **Permissions**: Member access required for all operations
- **Concurrency**: Stale write protection with lastKnownUpdatedAt parameter
- **Testing**: Added unit tests for serialization functionality

## Implementation Details
- Filters support statuses, assignee, includeUnassigned, assignedToMe, and tagIds
- JSON serialization/deserialization for storing filters in database
- Proper error handling with standardized GraphQL error codes
- Any member can manage views and set default views (per spec)
- Default view clearing supported by passing null savedViewId

## Dependencies Satisfied
- Depends on migrations (011) and permissions (004) ✅
- Completes ticket .rovodev/todo-app-012_server_graphql_saved_views.md ✅

## Spec Compliance
Implements all requirements from spec sections §§5,8,10 including unique name validation and member-level permissions.